### PR TITLE
Update DateReadout_DateOnGUI.cs

### DIFF
--- a/Source/BetterTimeFormat/DateReadout_DateOnGUI.cs
+++ b/Source/BetterTimeFormat/DateReadout_DateOnGUI.cs
@@ -66,6 +66,8 @@ internal static class DateReadout_DateOnGUI
                 if (Prefs.TwelveHourClockMode && hours > 12)
                 {
                     hours %= 12;
+                    if (hours == 0)
+                        hours = 12;
                 }
 
                 userTime = userTime.ReplaceFirst("HH", $"{hours,0:00}");


### PR DESCRIPTION
Fix for 12 hour mode showing midnight as 0:XX AM or 00:XX AM depending on H or HH